### PR TITLE
Phase 3: Playground feature + client refactor

### DIFF
--- a/codesociety-client/package-lock.json
+++ b/codesociety-client/package-lock.json
@@ -8,6 +8,11 @@
       "name": "codesociety-client",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-cpp": "^6.0.2",
+        "@codemirror/lang-java": "^6.0.1",
+        "@codemirror/lang-python": "^6.1.7",
+        "@codemirror/theme-one-dark": "^6.1.2",
+        "@uiw/react-codemirror": "^4.23.10",
         "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -280,6 +285,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
@@ -336,6 +353,131 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.2.tgz",
+      "integrity": "sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.1.tgz",
+      "integrity": "sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.7.tgz",
+      "integrity": "sha512-mZnFTsL4lW5p9ch8uKNKeRU3xGGxr1QpESLilfON2E3fQzOa/OygEMkaDvERvXDJWJA9U9oN/D4w0ZuUzNO4+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+      "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
+      "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
+      "integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.36.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.5.tgz",
+      "integrity": "sha512-cd+FZEUlu3GQCYnguYm3EkhJ8KJVisqqUsCOKedBoAt/d9c76JUUap6U0UrpElln5k6VyrEOYliMuDAKIeDQLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1064,6 +1206,69 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.3.tgz",
+      "integrity": "sha512-ykYvuFQKGsRi6IcE+/hCSGUhb/I4WPjd3ELhEblm2wS2cOznDFzO+ubK2c+ioysOnlZ3EduV+MVQFCPzAIoY3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1478,6 +1683,59 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.23.10.tgz",
+      "integrity": "sha512-zpbmSeNs3OU/f/Eyd6brFnjsBUYwv2mFjWxlAsIRSwTlW+skIT60rQHFBSfsj/5UVSxSLWVeUYczN7AyXvgTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.10.tgz",
+      "integrity": "sha512-AbN4eVHOL4ckRuIXpZxkzEqL/1ChVA+BSdEnAKjIB68pLQvKsVoYbiFP8zkXkYc4+Fcgq5KbAjvYqdo4ewemKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.23.10",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
@@ -1852,6 +2110,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1916,6 +2189,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3638,6 +3917,12 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3929,6 +4214,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -4197,6 +4488,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/codesociety-client/package.json
+++ b/codesociety-client/package.json
@@ -10,6 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-cpp": "^6.0.2",
+    "@codemirror/lang-java": "^6.0.1",
+    "@codemirror/lang-python": "^6.1.7",
+    "@codemirror/theme-one-dark": "^6.1.2",
+    "@uiw/react-codemirror": "^4.23.10",
     "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/codesociety-client/src/App.jsx
+++ b/codesociety-client/src/App.jsx
@@ -4,15 +4,16 @@ import Footer from "./components/Footer/Footer.jsx";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
-import Register from "./pages/Register/Register.jsx";
-import Home from "./pages/Home/Home.jsx";
-import Login from "./pages/Login/Login.jsx";
-import Profile from "./pages/Profile/Profile.jsx";
+import Register from "./pages/Register";
+import Home from "./pages/Home";
+import Login from "./pages/Login";
+import Profile from "./pages/Profile";
 import ProblemsList from "./pages/Problems/ProblemsList.jsx";
 import ProblemDetail from "./pages/Problems/ProblemDetail.jsx";
-import Leaderboard from "./pages/Leaderboard/Leaderboard.jsx";
+import Leaderboard from "./pages/Leaderboard";
+import Playground from "./pages/Playground";
 
-import PrivateRoute from "./context/PrivateRoute"; // ✅ added
+import PrivateRoute from "./context/PrivateRoute";
 
 function App() {
   return (
@@ -22,11 +23,13 @@ function App() {
 
         <div className="flex-grow overflow-y-auto pt-20 pb-20">
           <Routes>
+            {/* Public Routes */}
             <Route path="/" element={<Home />} />
             <Route path="/register" element={<Register />} />
             <Route path="/login" element={<Login />} />
+            <Route path="/playground" element={<Playground />} /> {/* ✅ Playground route */}
 
-            {/* ✅ Protected Routes */}
+            {/* Protected Routes */}
             <Route path="/profile" element={
               <PrivateRoute>
                 <Profile />

--- a/codesociety-client/src/components/CodeEditor/CodeEditor.jsx
+++ b/codesociety-client/src/components/CodeEditor/CodeEditor.jsx
@@ -1,0 +1,93 @@
+import CodeMirror from "@uiw/react-codemirror";
+import { cpp } from "@codemirror/lang-cpp";
+import { java } from "@codemirror/lang-java";
+import { python } from "@codemirror/lang-python";
+import { useEffect, useState } from "react";
+
+const getLanguageExtension = (lang) => {
+  switch (lang) {
+    case "cpp":
+      return cpp();
+    case "java":
+      return java();
+    case "python":
+      return python();
+    default:
+      return [];
+  }
+};
+
+const Editor = ({
+  value,
+  onChange,
+  language,
+  onLanguageChange,
+  onSubmit,
+  onReset,
+  showSubmit = true,
+}) => {
+  const [extension, setExtension] = useState([]);
+
+  useEffect(() => {
+    setExtension([getLanguageExtension(language)]);
+  }, [language]);
+
+  return (
+    <div className="bg-white shadow rounded-lg p-4 space-y-4">
+      {/* Language Dropdown + Reset */}
+      <div className="flex justify-between items-center">
+        <div>
+          <label className="text-gray-700 font-semibold">Language:</label>
+          <select
+            value={language}
+            onChange={(e) => onLanguageChange(e.target.value)}
+            className="ml-2 border border-gray-300 rounded px-3 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">Select Language</option>
+            <option value="cpp">C++</option>
+            <option value="java">Java</option>
+            <option value="python">Python</option>
+          </select>
+        </div>
+
+        {onReset && (
+          <button
+            onClick={onReset}
+            className="border border-gray-400 text-gray-700 px-4 py-1 rounded hover:bg-gray-100 transition text-sm font-medium"
+          >
+            Reset to Template
+          </button>
+        )}
+      </div>
+
+      {/* Code Editor */}
+      <CodeMirror
+        value={value}
+        height="400px"
+        extensions={extension}
+        theme="light"
+        onChange={(val) => onChange(val)}
+      />
+
+      {/* Buttons */}
+      {showSubmit && (
+        <div className="flex gap-4">
+          <button
+            onClick={onSubmit}
+            className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 transition font-semibold"
+          >
+            Submit
+          </button>
+          <button
+            onClick={onSubmit}
+            className="bg-yellow-400 hover:bg-yellow-500 text-gray-900 font-semibold px-6 py-2 rounded transition"
+          >
+            Run Code
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Editor;

--- a/codesociety-client/src/components/CodeEditor/index.js
+++ b/codesociety-client/src/components/CodeEditor/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CodeEditor";

--- a/codesociety-client/src/pages/Home/Home.jsx
+++ b/codesociety-client/src/pages/Home/Home.jsx
@@ -31,7 +31,7 @@ const Home = () => {
         </p>
 
         {/* CTA Buttons */}
-        <div className="flex flex-wrap gap-4 justify-center">
+        <div className="flex flex-wrap gap-4 justify-center mb-8">
           {user ? (
             <>
               <Link
@@ -45,6 +45,13 @@ const Home = () => {
                 className="border border-blue-600 text-blue-600 hover:bg-blue-100 px-6 py-3 rounded-lg font-semibold transition-all duration-200"
               >
                 Go to Profile
+              </Link>
+              {/* Playground CTA visible only to logged in users */}
+              <Link
+                to="/playground"
+                className="border border-yellow-500 text-yellow-600 hover:bg-yellow-50 px-6 py-3 rounded-lg font-semibold transition-all duration-200"
+              >
+                Try Playground
               </Link>
             </>
           ) : (

--- a/codesociety-client/src/pages/Home/index.js
+++ b/codesociety-client/src/pages/Home/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Home";

--- a/codesociety-client/src/pages/Leaderboard/index.js
+++ b/codesociety-client/src/pages/Leaderboard/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Leaderboard";

--- a/codesociety-client/src/pages/Login/Login.jsx
+++ b/codesociety-client/src/pages/Login/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 import { toast } from "react-toastify";
 
@@ -50,7 +50,7 @@ function Login() {
         </p>
       </div>
 
-      <div className="flex-1 bg-white flex items-center justify-center p-8">
+      <div className="flex-1 bg-white flex flex-col justify-center items-center p-8">
         <div className="w-full max-w-md">
           <h2 className="text-2xl font-bold mb-6 text-center text-gray-800">Login</h2>
 
@@ -88,6 +88,19 @@ function Login() {
               Login
             </button>
           </form>
+
+          {/* Playground CTA */}
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-500 mb-2">
+              Want to just try writing code first?
+            </p>
+            <Link
+              to="/playground"
+              className="inline-block border border-yellow-500 text-yellow-600 hover:bg-yellow-50 px-4 py-2 rounded-lg font-semibold transition-all duration-200 text-sm"
+            >
+              Try Playground
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/codesociety-client/src/pages/Login/index.js
+++ b/codesociety-client/src/pages/Login/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Login";

--- a/codesociety-client/src/pages/Playground/Playground.jsx
+++ b/codesociety-client/src/pages/Playground/Playground.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import Body from "../../components/Layout/Body";
+import Editor from "../../components/CodeEditor";
+
+const codeTemplates = {
+  cpp: `#include <iostream>
+using namespace std;
+
+int main() {
+    // your code here
+    return 0;
+}`,
+  java: `public class Main {
+    public static void main(String[] args) {
+        // your code here
+    }
+}`,
+  python: `def main():
+    # your code here
+    pass
+
+if __name__ == "__main__":
+    main()`
+};
+
+const Playground = () => {
+  const [codes, setCodes] = useState({
+    cpp: "",
+    java: "",
+    python: ""
+  });
+
+  const [language, setLanguage] = useState("");
+  const [testInput, setTestInput] = useState("");
+  const [output, setOutput] = useState("");
+
+  const handleLanguageChange = (lang) => {
+    setLanguage(lang);
+    if (!codes[lang] && codeTemplates[lang]) {
+      setCodes((prev) => ({ ...prev, [lang]: codeTemplates[lang] }));
+    }
+  };
+
+  const handleCodeChange = (val) => {
+    setCodes((prev) => ({ ...prev, [language]: val }));
+  };
+
+  const handleReset = () => {
+    if (language) {
+      setCodes((prev) => ({ ...prev, [language]: codeTemplates[language] || "" }));
+    }
+  };
+
+  const handleRun = async () => {
+    if (!language || !codes[language]) {
+      alert("Please select a language and enter some code.");
+      return;
+    }
+
+    const normalizedCode = codes[language].replace(/\t/g, "    ");
+
+    try {
+      const res = await axios.post("http://localhost:8002/run", {
+        code: normalizedCode,
+        language,
+        input: testInput,
+      });
+
+      setOutput(res.data.output);
+    } catch (err) {
+      setOutput(err.response?.data?.error || "Something went wrong");
+    }
+  };
+
+  return (
+    <Body>
+      <div className="min-h-[calc(100vh-160px)] px-4 py-6 max-w-5xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-2">💡 Playground</h1>
+        <p className="text-gray-600 mb-6">
+          Write and test code freely with your own input.
+        </p>
+
+        <Editor
+          value={codes[language] || ""}
+          onChange={handleCodeChange}
+          language={language}
+          onLanguageChange={handleLanguageChange}
+          showSubmit={true}
+          onSubmit={handleRun}
+          onReset={handleReset}
+        />
+
+        {/* Input Box */}
+        <div className="mt-6">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Custom Input
+          </label>
+          <textarea
+            rows="4"
+            className="w-full border border-gray-300 rounded-lg p-3 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Enter input for your code (e.g., test cases)"
+            value={testInput}
+            onChange={(e) => setTestInput(e.target.value)}
+          />
+        </div>
+
+        {/* Output Section */}
+        {output && (
+          <div className="mt-6 bg-gray-100 p-4 rounded border">
+            <h3 className="text-lg font-semibold text-gray-700 mb-2">Output:</h3>
+            <pre className="font-mono text-sm text-gray-800 whitespace-pre-wrap">
+              {output}
+            </pre>
+          </div>
+        )}
+      </div>
+    </Body>
+  );
+};
+
+export default Playground;

--- a/codesociety-client/src/pages/Playground/index.js
+++ b/codesociety-client/src/pages/Playground/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Playground";

--- a/codesociety-client/src/pages/Profile/index.js
+++ b/codesociety-client/src/pages/Profile/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Profile";

--- a/codesociety-client/src/pages/Register/index.js
+++ b/codesociety-client/src/pages/Register/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Register";


### PR DESCRIPTION
## Summary
- Added CodeMirror-based code editor component (C++, Java, Python support)
- Added Playground page with custom input and output display
- Surfaced Playground via CTAs on Home and Login pages
- Added barrel `index.js` exports across all page directories for cleaner imports
- Added Playground route in App.jsx

## Test plan
- [ ] Visit `/playground` and verify the code editor loads
- [ ] Switch between C++, Java, Python and verify syntax highlighting changes
- [ ] Enter code + custom input and click Run — should hit the execution worker at `localhost:8002`
- [ ] Click "Reset to Template" and verify code resets to the language default
- [ ] On Home page (logged in), verify "Try Playground" button appears and navigates correctly
- [ ] On Login page, verify "Try Playground" link appears below the form
- [ ] Verify all page imports still resolve correctly via barrel exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)